### PR TITLE
Reorders service configuration calls for logging for https://github.com/innago-property-management/heap-client/issues/4.

### DIFF
--- a/src/Service/ProgramConfiguration.cs
+++ b/src/Service/ProgramConfiguration.cs
@@ -17,9 +17,12 @@ internal static class ProgramConfiguration
     public static void ConfigureServices(this IServiceCollection services, IConfiguration configuration, IWebHostEnvironment environment)
     {
         services.AddOpenApi();
+        
         services.AddOpenTelemetry().WithTracing(ConfigureTracing);
-        services.AddSerilog();
+        
         services.AddLogging();
+        services.AddSerilog();
+        
         services.AddHealthChecks().ForwardToPrometheus();
 
         services.AddKeyedScoped<RestClient>("heap", (_, _) => 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure Serilog is registered after the ASP.NET Core logging service by swapping the order of AddLogging and AddSerilog calls