### PR TITLE
Adds OpenAPI spec and contact info to Heap service

### DIFF
--- a/src/Service/PublicAPI.Shipped.txt
+++ b/src/Service/PublicAPI.Shipped.txt
@@ -38,4 +38,3 @@ virtual Innago.Shared.HeapService.Handlers.Track.TrackEventParameters.Equals(Inn
 virtual Innago.Shared.HeapService.Handlers.Track.TrackEventParameters.<Clone>$() -> Innago.Shared.HeapService.Handlers.Track.TrackEventParameters!
 Innago.Shared.HeapService.Handlers.Track.TrackEventParameters.Deconstruct(out string! EmailAddress, out string! EventName, out System.DateTimeOffset Timestamp, out System.Collections.Generic.Dictionary<string!, string!>? AdditionalProperties) -> void
 override Innago.Shared.HeapService.Handlers.Track.TrackEventParameters.GetHashCode() -> int
-static Innago.Shared.HeapService.Handlers.Track.Track.TrackEvent(Innago.Shared.HeapService.Handlers.Track.TrackEventParameters! parameters, RestSharp.RestClient! client, Microsoft.Extensions.Logging.ILoggerFactory! loggerFactory, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Http.IResult!>!

--- a/src/Service/Service.json
+++ b/src/Service/Service.json
@@ -2,6 +2,14 @@
   "openapi": "3.0.1",
   "info": {
     "title": "Innago.Shared.HeapService | v1",
+    "contact": {
+      "name": "Support Team",
+      "email": "support@innago.com"
+    },
+    "license": {
+      "name": "MIT License",
+      "url": "https://opensource.org/licenses/MIT"
+    },
     "version": "1.0.0"
   },
   "paths": {
@@ -10,6 +18,8 @@
         "tags": [
           "heap"
         ],
+        "summary": "Forwards event to heap analytics service",
+        "description": "Tracks an event for a specific user with associated properties using the configured Heap client.",
         "requestBody": {
           "content": {
             "application/json": {
@@ -58,8 +68,22 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "openIdConnect",
+        "description": "Enter your JWT token in the format 'Bearer {token}' to access this API.",
+        "openIdConnectUrl": "https://my-api.innago.com/connect/token"
+      }
     }
   },
+  "security": [
+    {
+      "BearerAuth": [
+        "heap"
+      ]
+    }
+  ],
   "tags": [
     {
       "name": "heap"


### PR DESCRIPTION
## Summary by Sourcery

Consolidate configuration setup and enrich the OpenAPI specification with contact, license, and security details.

Enhancements:
- Consolidate application builder and endpoint registration by removing duplicated methods and centralizing ConfigureApplicationBuilder and ConfigureRoutes in ProgramConfiguration

Documentation:
- Enhance generated OpenAPI document with support team contact info, MIT license, and a BearerAuth security scheme with OAuth flow